### PR TITLE
Zerofication of heterogeneous collections' arguments

### DIFF
--- a/src/Data/SOP/Interfaces.idr
+++ b/src/Data/SOP/Interfaces.idr
@@ -28,7 +28,7 @@ AllC k (List $ List (k)) where
 %inline
 public export
 HCont : (k : Type) -> (l : Type) -> Type
-HCont k l = (k -> Type) -> l -> Type
+HCont k l = (0 _ : k -> Type) -> l -> Type
 
 --------------------------------------------------------------------------------
 --          HFunctor

--- a/src/Data/SOP/Interfaces.idr
+++ b/src/Data/SOP/Interfaces.idr
@@ -24,6 +24,12 @@ AllC k (List $ List (k)) where
   All f []          = ()
   All f (ks :: kss) = (All f ks, All f kss)
 
+-- Heterogeneous container
+%inline
+public export
+HCont : (k : Type) -> (l : Type) -> Type
+HCont k l = (k -> Type) -> l -> Type
+
 --------------------------------------------------------------------------------
 --          HFunctor
 --------------------------------------------------------------------------------
@@ -40,7 +46,7 @@ AllC k (List $ List (k)) where
 ||| HFunctor k (List k) (NP' k) where
 ||| ```
 public export
-interface AllC k l => HFunctor k l (p : (k -> Type) -> l -> Type) | p where 
+interface AllC k l => HFunctor k l (p : HCont k l) | p where
   ||| Maps the given function over all values in a
   ||| heterogeneous container, thus changing the wrappers
   ||| of all of its values.
@@ -108,7 +114,7 @@ hcliftA = hcmap
 ||| See `HFunctor` for an explanation of the type parameters
 ||| used here.
 public export
-interface HFunctor k l p => HPure k l (p : (k -> Type) -> l -> Type) | p where
+interface HFunctor k l p => HPure k l (p : HCont k l) | p where
   ||| Creates a heterogeneous container by generating values
   ||| using the given function.
   |||
@@ -216,7 +222,7 @@ hcliftA3 c fun fs gs hs = hcliftA2 c fun fs gs `hap` hs
 --------------------------------------------------------------------------------
 
 public export
-interface HFold k l (p : (k -> Type) -> l -> Type) | p where
+interface HFold k l (p : HCont k l) | p where
   hfoldl : {0 ks : l} -> (acc -> elem -> acc) -> acc -> p (K elem) ks -> acc
 
   hfoldr : {0 ks : l} -> (elem -> acc -> acc) -> acc -> p (K elem) ks -> acc
@@ -283,7 +289,7 @@ hany fun = hor . hmap fun
 --------------------------------------------------------------------------------
 
 public export
-interface HSequence k l (p : (k -> Type) -> l -> Type) | p where
+interface HSequence k l (p : HCont k l) | p where
   hsequence :  {0 ks : l}
             -> {0 f : k -> Type}
             -> Applicative g

--- a/src/Data/SOP/Interfaces.idr
+++ b/src/Data/SOP/Interfaces.idr
@@ -28,7 +28,7 @@ AllC k (List $ List (k)) where
 %inline
 public export
 HCont : (k : Type) -> (l : Type) -> Type
-HCont k l = (0 _ : k -> Type) -> l -> Type
+HCont k l = (0 _ : k -> Type) -> (0 _ : l) -> Type
 
 --------------------------------------------------------------------------------
 --          HFunctor

--- a/src/Data/SOP/NP.idr
+++ b/src/Data/SOP/NP.idr
@@ -45,7 +45,7 @@ import Decidable.Equality
 ||| ex3 = [Just 'x', Nothing, Just 1]
 ||| ```
 public export
-data NP' : (k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
+data NP' : (0 k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
   Nil  : NP' k f []
   (::) : (v : f t) -> (vs : NP' k f ks) -> NP' k f (t :: ks)
 
@@ -53,7 +53,7 @@ data NP' : (k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-NP : {k : Type} -> (f : k -> Type) -> (ks : List k) -> Type
+NP : {0 k : Type} -> (f : k -> Type) -> (ks : List k) -> Type
 NP = NP' k
 
 public export

--- a/src/Data/SOP/NP.idr
+++ b/src/Data/SOP/NP.idr
@@ -45,7 +45,7 @@ import Decidable.Equality
 ||| ex3 = [Just 'x', Nothing, Just 1]
 ||| ```
 public export
-data NP' : (0 k : Type) -> (0 f : k -> Type) -> (ks : List k) -> Type where
+data NP' : (0 k : Type) -> (0 f : k -> Type) -> (0 ks : List k) -> Type where
   Nil  : NP' k f []
   (::) : (v : f t) -> (vs : NP' k f ks) -> NP' k f (t :: ks)
 
@@ -53,7 +53,7 @@ data NP' : (0 k : Type) -> (0 f : k -> Type) -> (ks : List k) -> Type where
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-NP : {0 k : Type} -> (0 f : k -> Type) -> (ks : List k) -> Type
+NP : {0 k : Type} -> (0 f : k -> Type) -> (0 ks : List k) -> Type
 NP = NP' k
 
 public export

--- a/src/Data/SOP/NP.idr
+++ b/src/Data/SOP/NP.idr
@@ -45,7 +45,7 @@ import Decidable.Equality
 ||| ex3 = [Just 'x', Nothing, Just 1]
 ||| ```
 public export
-data NP' : (0 k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
+data NP' : (0 k : Type) -> (0 f : k -> Type) -> (ks : List k) -> Type where
   Nil  : NP' k f []
   (::) : (v : f t) -> (vs : NP' k f ks) -> NP' k f (t :: ks)
 
@@ -53,7 +53,7 @@ data NP' : (0 k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-NP : {0 k : Type} -> (f : k -> Type) -> (ks : List k) -> Type
+NP : {0 k : Type} -> (0 f : k -> Type) -> (ks : List k) -> Type
 NP = NP' k
 
 public export

--- a/src/Data/SOP/NS.idr
+++ b/src/Data/SOP/NS.idr
@@ -38,7 +38,7 @@ import Decidable.Equality
 ||| the (NS' Type I [Char,Bool]) (S $ Z False)
 ||| ```
 public export
-data NS' : (0 k : Type) -> (0 f : k -> Type) -> (ks : List k) -> Type where
+data NS' : (0 k : Type) -> (0 f : k -> Type) -> (0 ks : List k) -> Type where
   Z : (v : f t)  -> NS' k f (t :: ks)
   S : NS' k f ks -> NS' k f (t :: ks)
 
@@ -46,7 +46,7 @@ data NS' : (0 k : Type) -> (0 f : k -> Type) -> (ks : List k) -> Type where
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-NS : {0 k : Type} -> (0 f : k -> Type) -> (ks : List k) -> Type
+NS : {0 k : Type} -> (0 f : k -> Type) -> (0 ks : List k) -> Type
 NS = NS' k
 
 --------------------------------------------------------------------------------

--- a/src/Data/SOP/NS.idr
+++ b/src/Data/SOP/NS.idr
@@ -38,7 +38,7 @@ import Decidable.Equality
 ||| the (NS' Type I [Char,Bool]) (S $ Z False)
 ||| ```
 public export
-data NS' : (0 k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
+data NS' : (0 k : Type) -> (0 f : k -> Type) -> (ks : List k) -> Type where
   Z : (v : f t)  -> NS' k f (t :: ks)
   S : NS' k f ks -> NS' k f (t :: ks)
 
@@ -46,7 +46,7 @@ data NS' : (0 k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-NS : {0 k : Type} -> (f : k -> Type) -> (ks : List k) -> Type
+NS : {0 k : Type} -> (0 f : k -> Type) -> (ks : List k) -> Type
 NS = NS' k
 
 --------------------------------------------------------------------------------

--- a/src/Data/SOP/NS.idr
+++ b/src/Data/SOP/NS.idr
@@ -38,7 +38,7 @@ import Decidable.Equality
 ||| the (NS' Type I [Char,Bool]) (S $ Z False)
 ||| ```
 public export
-data NS' : (k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
+data NS' : (0 k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
   Z : (v : f t)  -> NS' k f (t :: ks)
   S : NS' k f ks -> NS' k f (t :: ks)
 
@@ -46,7 +46,7 @@ data NS' : (k : Type) -> (f : k -> Type) -> (ks : List k) -> Type where
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-NS : {k : Type} -> (f : k -> Type) -> (ks : List k) -> Type
+NS : {0 k : Type} -> (f : k -> Type) -> (ks : List k) -> Type
 NS = NS' k
 
 --------------------------------------------------------------------------------

--- a/src/Data/SOP/POP.idr
+++ b/src/Data/SOP/POP.idr
@@ -22,7 +22,7 @@ import Decidable.Equality
 ||| generic programming, a POP is useful to represent information
 ||| that is available for all arguments of all constructors of a datatype.
 public export
-data POP' : (0 k : Type) -> (0 f : k -> Type) -> (kss : List (List k)) -> Type where
+data POP' : (0 k : Type) -> (0 f : k -> Type) -> (0 kss : List (List k)) -> Type where
   Nil  : POP' k f []
   (::) : (vs : NP' k f ks) -> (vss : POP' k f kss) -> POP' k f (ks :: kss)
 
@@ -30,7 +30,7 @@ data POP' : (0 k : Type) -> (0 f : k -> Type) -> (kss : List (List k)) -> Type w
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-POP : {0 k : Type} -> (0 f : k -> Type) -> (kss : List (List k)) -> Type
+POP : {0 k : Type} -> (0 f : k -> Type) -> (0 kss : List (List k)) -> Type
 POP = POP' k
 
 --------------------------------------------------------------------------------

--- a/src/Data/SOP/POP.idr
+++ b/src/Data/SOP/POP.idr
@@ -22,7 +22,7 @@ import Decidable.Equality
 ||| generic programming, a POP is useful to represent information
 ||| that is available for all arguments of all constructors of a datatype.
 public export
-data POP' : (k : Type) -> (f : k -> Type) -> (kss : List (List k)) -> Type where
+data POP' : (0 k : Type) -> (f : k -> Type) -> (kss : List (List k)) -> Type where
   Nil  : POP' k f []
   (::) : (vs : NP' k f ks) -> (vss : POP' k f kss) -> POP' k f (ks :: kss)
 
@@ -30,7 +30,7 @@ data POP' : (k : Type) -> (f : k -> Type) -> (kss : List (List k)) -> Type where
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-POP : {k : Type} -> (f : k -> Type) -> (kss : List (List k)) -> Type
+POP : {0 k : Type} -> (f : k -> Type) -> (kss : List (List k)) -> Type
 POP = POP' k
 
 --------------------------------------------------------------------------------

--- a/src/Data/SOP/POP.idr
+++ b/src/Data/SOP/POP.idr
@@ -22,7 +22,7 @@ import Decidable.Equality
 ||| generic programming, a POP is useful to represent information
 ||| that is available for all arguments of all constructors of a datatype.
 public export
-data POP' : (0 k : Type) -> (f : k -> Type) -> (kss : List (List k)) -> Type where
+data POP' : (0 k : Type) -> (0 f : k -> Type) -> (kss : List (List k)) -> Type where
   Nil  : POP' k f []
   (::) : (vs : NP' k f ks) -> (vss : POP' k f kss) -> POP' k f (ks :: kss)
 
@@ -30,7 +30,7 @@ data POP' : (0 k : Type) -> (f : k -> Type) -> (kss : List (List k)) -> Type whe
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-POP : {0 k : Type} -> (f : k -> Type) -> (kss : List (List k)) -> Type
+POP : {0 k : Type} -> (0 f : k -> Type) -> (kss : List (List k)) -> Type
 POP = POP' k
 
 --------------------------------------------------------------------------------

--- a/src/Data/SOP/SOP.idr
+++ b/src/Data/SOP/SOP.idr
@@ -21,7 +21,7 @@ import Decidable.Equality
 ||| represents the choice between the different constructors, the product structure
 ||| represents the arguments of each constructor.
 public export
-data SOP' : (0 k : Type) -> (f : k -> Type) -> (kss : List $ List k) -> Type where
+data SOP' : (0 k : Type) -> (0 f : k -> Type) -> (kss : List $ List k) -> Type where
   Z : (vs : NP' k f ks)  -> SOP' k f (ks :: kss)
   S : SOP' k f kss -> SOP' k f (ks :: kss)
 
@@ -29,7 +29,7 @@ data SOP' : (0 k : Type) -> (f : k -> Type) -> (kss : List $ List k) -> Type whe
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-SOP : {0 k : Type} -> (f : k -> Type) -> (kss : List (List k)) -> Type
+SOP : {0 k : Type} -> (0 f : k -> Type) -> (kss : List (List k)) -> Type
 SOP = SOP' k
 
 --------------------------------------------------------------------------------

--- a/src/Data/SOP/SOP.idr
+++ b/src/Data/SOP/SOP.idr
@@ -21,7 +21,7 @@ import Decidable.Equality
 ||| represents the choice between the different constructors, the product structure
 ||| represents the arguments of each constructor.
 public export
-data SOP' : (k : Type) -> (f : k -> Type) -> (kss : List $ List k) -> Type where
+data SOP' : (0 k : Type) -> (f : k -> Type) -> (kss : List $ List k) -> Type where
   Z : (vs : NP' k f ks)  -> SOP' k f (ks :: kss)
   S : SOP' k f kss -> SOP' k f (ks :: kss)
 
@@ -29,7 +29,7 @@ data SOP' : (k : Type) -> (f : k -> Type) -> (kss : List $ List k) -> Type where
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-SOP : {k : Type} -> (f : k -> Type) -> (kss : List (List k)) -> Type
+SOP : {0 k : Type} -> (f : k -> Type) -> (kss : List (List k)) -> Type
 SOP = SOP' k
 
 --------------------------------------------------------------------------------

--- a/src/Data/SOP/SOP.idr
+++ b/src/Data/SOP/SOP.idr
@@ -21,7 +21,7 @@ import Decidable.Equality
 ||| represents the choice between the different constructors, the product structure
 ||| represents the arguments of each constructor.
 public export
-data SOP' : (0 k : Type) -> (0 f : k -> Type) -> (kss : List $ List k) -> Type where
+data SOP' : (0 k : Type) -> (0 f : k -> Type) -> (0 kss : List $ List k) -> Type where
   Z : (vs : NP' k f ks)  -> SOP' k f (ks :: kss)
   S : SOP' k f kss -> SOP' k f (ks :: kss)
 
@@ -29,7 +29,7 @@ data SOP' : (0 k : Type) -> (0 f : k -> Type) -> (kss : List $ List k) -> Type w
 ||| implicit. This reflects the kind-polymorphic data type
 ||| in Haskell.
 public export
-SOP : {0 k : Type} -> (0 f : k -> Type) -> (kss : List (List k)) -> Type
+SOP : {0 k : Type} -> (0 f : k -> Type) -> (0 kss : List (List k)) -> Type
 SOP = SOP' k
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This, actually, does not do anything much except for making impossible in the future to accidently add a function to the `H*` interfaces that contains non-zero-quantity arguments for `k` and `f`.